### PR TITLE
QoL changes to part cfg files

### DIFF
--- a/GameData/SurfaceExperimentPackage/Parts/GolfClub/part.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/GolfClub/part.cfg
@@ -59,7 +59,7 @@ tags = cck-eva-items sep kis kas surface experiment inventory science eva resear
 	MODULE
 	{
         name = ModuleKISItem
-        shortcutKeyAction = drop
+        shortcutKeyAction = equip
         usableFromEva = false
         usableFromContainer = false
         usableFromPod = false

--- a/GameData/SurfaceExperimentPackage/Parts/SEP_Box.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/SEP_Box.cfg
@@ -30,7 +30,7 @@ MODEL
 	breakingTorque = 500
 	bulkheadProfiles = size1, srf
 	
-	tags = cck-eva-items kis kas surface experiment inventory attachment eva storage container box cardboard 
+	tags = cck-containers cck-eva-items kis kas surface experiment inventory attachment eva storage container box cardboard 
 	
 	MODULE
 	{

--- a/GameData/SurfaceExperimentPackage/Parts/SEP_Screwdriver.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/SEP_Screwdriver.cfg
@@ -35,6 +35,7 @@ PART
 		name = ModuleKISItemAttachTool
 		shortcutKeyAction = equip
 		equipable = true
+		stackable = true
 		equipSkill = RepairSkill
 		equipSlot = rightHand
 		equipMeshName = body01

--- a/GameData/SurfaceExperimentPackage/Parts/SEP_StorageLong.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/SEP_StorageLong.cfg
@@ -30,7 +30,7 @@ MODEL
 	breakingTorque = 50
 	bulkheadProfiles = size1, srf
 	
-	tags = cck-eva-items kis kas surface experiment inventory attachment eva storage container box cardboard 
+	tags = cck-containers kis kas surface experiment inventory attachment eva storage container locker 
 	
 	MODULE
 	{

--- a/GameData/SurfaceExperimentPackage/Parts/SEP_StorageShort.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/SEP_StorageShort.cfg
@@ -31,7 +31,7 @@ MODEL
 	breakingTorque = 50
 	bulkheadProfiles = size1, srf
 	
-	tags = cck-eva-items kis kas surface experiment inventory attachment eva storage container box cardboard 
+	tags = cck-containers kis kas surface experiment inventory attachment eva storage container locker 
 	
 	MODULE
 	{

--- a/GameData/SurfaceExperimentPackage/Parts/SEP_girder.cfg
+++ b/GameData/SurfaceExperimentPackage/Parts/SEP_girder.cfg
@@ -37,7 +37,7 @@ PART
 	{
 		name = ModuleKISItem
 		volumeOverride = 25
-		stackable = false
+		stackable = true
 		allowStaticAttach = 1
 		staticAttachBreakForce = 2000
 	}


### PR DESCRIPTION
Cardboard box and lockers should be tagged cck-containers
Lockers should not be tagged cck-eva-items
Lockers should not be tagged cardboard box, tagged locker instead
KIS tools are stackable as of KIS 1.4.3, make screwdriver stackable to conform
Make girder stackable
Make Golf club's shortcutKeyAction equip rather than drop