### PR TITLE
Add .version file

### DIFF
--- a/GameData/SurfaceExperimentPackage/SurfaceExperimentPackage.version
+++ b/GameData/SurfaceExperimentPackage/SurfaceExperimentPackage.version
@@ -1,0 +1,22 @@
+{
+    "NAME":      "Surface Experiment Package",
+    "URL":       "https://raw.githubusercontent.com/CobaltWolf/Surface-Experiment-Pack/master/GameData/SurfaceExperimentPackage/SurfaceExperimentPackage.version",
+    "DOWNLOAD" : "https://github.com/CobaltWolf/Surface-Experiment-Pack/releases",
+    "GITHUB": {
+        "USERNAME":          "CobaltWolf",
+        "REPOSITORY":        "Surface-Experiment-Pack",
+        "ALLOW_PRE_RELEASE": false
+    },
+    "VERSION": {
+        "MAJOR": 2,
+        "MINOR": 7
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 4
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 6
+    }
+}


### PR DESCRIPTION
This will allow fine grained control of the game version compatibilities in CKAN as per [request on forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/155382-16x-surface-experiment-pack-deployable-science-for-kiskas-v27-13jan19/&do=findComment&comment=3523285).

The numbers in the file reflect the current release; remember to update when creating a new release. We will need to modify the netkan to use this info once there's a release with it.